### PR TITLE
Explicit module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "esnext",
     "module": "commonjs",
+    "moduleResolution": "node",
     "declaration": true,
     "strict": true
   }


### PR DESCRIPTION
I think the build errors are due to TypeScript not seeing `ajv` or `events` properly. It works on my machine without this change so I can't test it locally, but this won't hurt to try.